### PR TITLE
Output by edges

### DIFF
--- a/parsegen/src/parser/grammar.rs
+++ b/parsegen/src/parser/grammar.rs
@@ -347,7 +347,7 @@ impl<'a> PossibleWords<'a> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Node {
     Leaf(Token),
     RuleStart(usize),

--- a/parsegen/src/parser/grammar.rs
+++ b/parsegen/src/parser/grammar.rs
@@ -348,6 +348,16 @@ pub enum Node {
     RuleEnd(usize, Token),
 }
 
+impl Display for Node {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Node::Leaf(l) => write!(f, "{l}"),
+            Node::RuleStart(i, l) => write!(f, "S{l}[{i}]"),
+            Node::RuleEnd(i, l) => write!(f, "E{l}[{i}]"),
+        }
+    }
+}
+
 impl Node {
     /// Returns `true` if the node is [`Leaf`].
     ///

--- a/parsegen/src/parser/lgraph.rs
+++ b/parsegen/src/parser/lgraph.rs
@@ -425,15 +425,15 @@ impl Path {
         for n in self.postfix_output() {
             match n {
                 Node::Leaf(t) => stack.push(ParseTree::new(t)),
-                Node::RuleEnd(prod_idx) => {
+                Node::RuleEnd(prod_idx, _) => {
                     let prod = g.productions().nth(prod_idx).unwrap();
                     let mut parent = ParseTree::new(prod.lhs());
                     parent.replace_with_production(0, prod, prod_idx);
 
                     let body = stack.split_off(stack.len() - prod.rhs().len());
                     assert_eq!(body.len(), prod.rhs().len());
-                    for (i, child) in body.into_iter().enumerate() {
-                        parent.replace_with_subtree(i, child);
+                    for (i, child) in body.into_iter().enumerate().rev() {
+                        parent.replace_with_subtree(i + 1, child);
                     }
                     stack.push(parent);
                 }

--- a/parsegen/src/parser/lgraph.rs
+++ b/parsegen/src/parser/lgraph.rs
@@ -294,6 +294,11 @@ impl Display for Lgraph {
                 write!(w2, "token=\"{}\", ", tok).unwrap();
                 write!(w1, "{}\\n", tok).unwrap();
             }
+            if let Some(out) = l.output() {
+                write!(w2, "output=\"{}\", ", out).unwrap();
+                write!(w1, "<{}>\\n", out).unwrap();
+            }
+
             if let Some(bracket) = l.bracket() {
                 let idx = bracket
                     .index()

--- a/parsegen/src/parser/lgraph.rs
+++ b/parsegen/src/parser/lgraph.rs
@@ -1,8 +1,8 @@
-use std::{collections::VecDeque, fmt::Display, io::Cursor, io::Write};
+use std::{fmt::Display, io::Cursor, io::Write};
 
 use crate::{regex::state_machine::StateMachine, tokenizer::Token};
 
-use super::grammar::{Grammar, TokenOrEnd};
+use super::grammar::{Grammar, Node, TokenOrEnd};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Bracket {
@@ -54,6 +54,7 @@ pub struct Item {
     tok: Option<TokenOrEnd>,
     look_ahead: Option<Vec<TokenOrEnd>>,
     bracket: Option<Bracket>,
+    output: Option<Node>,
 }
 
 impl Item {
@@ -61,12 +62,30 @@ impl Item {
         tok: Option<TokenOrEnd>,
         look_ahead: Option<Vec<TokenOrEnd>>,
         bracket: Option<Bracket>,
+        output: Option<Node>,
     ) -> Self {
         Self {
             tok,
             look_ahead,
             bracket,
+            output,
         }
+    }
+    pub fn with_token(mut self, tok: Option<TokenOrEnd>) -> Self {
+        self.tok = tok;
+        self
+    }
+    pub fn with_look_ahead(mut self, look_ahead: Option<Vec<TokenOrEnd>>) -> Self {
+        self.look_ahead = look_ahead;
+        self
+    }
+    pub fn with_bracket(mut self, bracket: Option<Bracket>) -> Self {
+        self.bracket = bracket;
+        self
+    }
+    pub fn with_output(mut self, output: Option<Node>) -> Self {
+        self.output = output;
+        self
     }
 
     pub fn tok(&self) -> Option<TokenOrEnd> {
@@ -472,6 +491,7 @@ impl<'a> Iterator for PossibleWords<'a> {
                             item.tok(),
                             item.look_ahead().map(|lk| lk.to_vec()),
                             Some(Bracket::Closed(top.unwrap())),
+                            None,
                         )
                     } else {
                         item.clone()

--- a/parsegen/src/parser/ll1.rs
+++ b/parsegen/src/parser/ll1.rs
@@ -94,20 +94,14 @@ impl Lgraph {
 
             ll1 = ll1.add_edge(
                 4 * prod_idx,
-                Item::new(
-                    None,
-                    None,
-                    Some(Bracket::new(prod_idx + prod_bracket_offset, true)),
-                ),
+                Item::default()
+                    .with_bracket(Some(Bracket::new(prod_idx + prod_bracket_offset, true))),
                 4 * prod_idx + 1,
             );
             ll1 = ll1.add_edge(
                 4 * prod_idx + 2,
-                Item::new(
-                    None,
-                    None,
-                    Some(Bracket::new(prod_idx + prod_bracket_offset, false)),
-                ),
+                Item::default()
+                    .with_bracket(Some(Bracket::new(prod_idx + prod_bracket_offset, false))),
                 4 * prod_idx + 3,
             );
             ll1 = ll1
@@ -130,11 +124,7 @@ impl Lgraph {
         // step 2: fill out the productions, connecting them when needed
         for (prod_idx, prod) in grammar.productions().enumerate() {
             if prod.rhs().is_empty() {
-                ll1 = ll1.add_edge(
-                    4 * prod_idx + 1,
-                    Item::new(None, None, None),
-                    4 * prod_idx + 2,
-                );
+                ll1 = ll1.add_edge(4 * prod_idx + 1, Item::default(), 4 * prod_idx + 2);
                 continue;
             }
             let mut source = 4 * prod_idx + 1;
@@ -148,18 +138,15 @@ impl Lgraph {
                 };
                 if grammar.is_terminal(t.clone()) {
                     let sym_id = grammar.terminal_index(t.clone()).unwrap();
-                    let item = Item::new(
-                        Some(TokenOrEnd::Token(t.clone())),
-                        None,
-                        Some(Bracket::new(sym_id + terminal_bracket_offset, true)),
-                    );
+                    let item = Item::default()
+                        .with_token(Some(TokenOrEnd::Token(t.clone())))
+                        .with_bracket(Some(Bracket::new(sym_id + terminal_bracket_offset, true)));
                     ll1 = ll1.add_edge(source, item, node_count).add_edge(
                         node_count,
-                        Item::new(
-                            None,
-                            None,
-                            Some(Bracket::new(sym_id + terminal_bracket_offset, false)),
-                        ),
+                        Item::default().with_bracket(Some(Bracket::new(
+                            sym_id + terminal_bracket_offset,
+                            false,
+                        ))),
                         target,
                     );
                     node_count += 1;
@@ -169,11 +156,9 @@ impl Lgraph {
                             continue;
                         }
 
-                        let a_item = Item::new(
-                            None,
-                            Some(look_aheads[prod2_idx].clone()),
-                            Some(Bracket::new(bracket_count, true)), // we will return to target
-                        );
+                        let a_item = Item::default()
+                            .with_look_ahead(Some(look_aheads[prod2_idx].clone()))
+                            .with_bracket(Some(Bracket::new(bracket_count, true)));
 
                         let first_beta = first.first_of_sent(&prod.rhs()[i + 1..]).unwrap();
                         let mut following = vec![];
@@ -193,11 +178,9 @@ impl Lgraph {
                                 }
                             }
                         }
-                        let b_item = Item::new(
-                            None,
-                            Some(following),
-                            Some(Bracket::new(bracket_count, false)),
-                        );
+                        let b_item = Item::default()
+                            .with_look_ahead(Some(following))
+                            .with_bracket(Some(Bracket::new(bracket_count, false)));
                         ll1 = ll1.add_edge(source, a_item, 4 * prod2_idx);
                         ll1 = ll1.add_edge(4 * prod2_idx + 3, b_item, target);
                         bracket_count += 1;
@@ -218,41 +201,30 @@ impl Lgraph {
             if prod.lhs() != start_symbol {
                 continue;
             }
-            let start_item = Item::new(
-                None,
-                Some(look_aheads[i].clone()),
-                Some(Bracket::new(bracket_count, true)),
-            );
-            let end_item = Item::new(
-                Some(TokenOrEnd::End),
-                None,
-                Some(Bracket::new(bracket_count, false)),
-            );
+            let start_item = Item::default()
+                .with_look_ahead(Some(look_aheads[i].clone()))
+                .with_bracket(Some(Bracket::new(bracket_count, true)));
+            let end_item = Item::default()
+                .with_token(Some(TokenOrEnd::End))
+                .with_bracket(Some(Bracket::new(bracket_count, false)));
+
             ll1 = ll1.add_edge(start_node, start_item, 4 * i);
             ll1 = ll1
                 .add_edge(4 * i + 3, end_item, node_count)
                 .add_edge(
                     node_count,
-                    Item::new(
-                        None,
-                        None,
-                        Some(Bracket::new(
-                            terminal_count - 1 + terminal_bracket_offset,
-                            true,
-                        )),
-                    ),
+                    Item::default().with_bracket(Some(Bracket::new(
+                        terminal_count - 1 + terminal_bracket_offset,
+                        true,
+                    ))),
                     node_count + 1,
                 )
                 .add_edge(
                     node_count + 1,
-                    Item::new(
-                        None,
-                        None,
-                        Some(Bracket::new(
-                            terminal_count - 1 + terminal_bracket_offset,
-                            false,
-                        )),
-                    ),
+                    Item::default().with_bracket(Some(Bracket::new(
+                        terminal_count - 1 + terminal_bracket_offset,
+                        false,
+                    ))),
                     end_node,
                 );
             node_count += 2;

--- a/parsegen/src/parser/ll1.rs
+++ b/parsegen/src/parser/ll1.rs
@@ -1,4 +1,7 @@
-use super::{grammar::Grammar, lgraph::Lgraph};
+use super::{
+    grammar::{Grammar, Node},
+    lgraph::Lgraph,
+};
 use crate::parser::{
     grammar::{TokenOrEnd, TokenOrEps},
     lgraph::{Bracket, Item},
@@ -64,7 +67,6 @@ impl Lgraph {
         let mut node_count = 0;
         let terminal_count = grammar.terminals().count() + 1;
         let prod_count = grammar.productions().count();
-        let terminal_bracket_offset = 0;
         let prod_bracket_offset = terminal_count;
         let mut bracket_count = prod_bracket_offset + prod_count;
         let mut look_aheads = vec![];
@@ -95,13 +97,15 @@ impl Lgraph {
             ll1 = ll1.add_edge(
                 4 * prod_idx,
                 Item::default()
-                    .with_bracket(Some(Bracket::new(prod_idx + prod_bracket_offset, true))),
+                    .with_bracket(Some(Bracket::new(prod_idx + prod_bracket_offset, true)))
+                    .with_output(Some(Node::RuleStart(prod_idx, prod.lhs()))),
                 4 * prod_idx + 1,
             );
             ll1 = ll1.add_edge(
                 4 * prod_idx + 2,
                 Item::default()
-                    .with_bracket(Some(Bracket::new(prod_idx + prod_bracket_offset, false))),
+                    .with_bracket(Some(Bracket::new(prod_idx + prod_bracket_offset, false)))
+                    .with_output(Some(Node::RuleEnd(prod_idx, prod.lhs()))),
                 4 * prod_idx + 3,
             );
             ll1 = ll1
@@ -137,19 +141,10 @@ impl Lgraph {
                     node_count - 1
                 };
                 if grammar.is_terminal(t.clone()) {
-                    let sym_id = grammar.terminal_index(t.clone()).unwrap();
                     let item = Item::default()
                         .with_token(Some(TokenOrEnd::Token(t.clone())))
-                        .with_bracket(Some(Bracket::new(sym_id + terminal_bracket_offset, true)));
-                    ll1 = ll1.add_edge(source, item, node_count).add_edge(
-                        node_count,
-                        Item::default().with_bracket(Some(Bracket::new(
-                            sym_id + terminal_bracket_offset,
-                            false,
-                        ))),
-                        target,
-                    );
-                    node_count += 1;
+                        .with_output(Some(Node::Leaf(t.clone())));
+                    ll1 = ll1.add_edge(source, item, target)
                 } else {
                     for (prod2_idx, prod2) in grammar.productions().enumerate() {
                         if &prod2.lhs() != t {
@@ -209,25 +204,12 @@ impl Lgraph {
                 .with_bracket(Some(Bracket::new(bracket_count, false)));
 
             ll1 = ll1.add_edge(start_node, start_item, 4 * i);
-            ll1 = ll1
-                .add_edge(4 * i + 3, end_item, node_count)
-                .add_edge(
-                    node_count,
-                    Item::default().with_bracket(Some(Bracket::new(
-                        terminal_count - 1 + terminal_bracket_offset,
-                        true,
-                    ))),
-                    node_count + 1,
-                )
-                .add_edge(
-                    node_count + 1,
-                    Item::default().with_bracket(Some(Bracket::new(
-                        terminal_count - 1 + terminal_bracket_offset,
-                        false,
-                    ))),
-                    end_node,
-                );
-            node_count += 2;
+            ll1 = ll1.add_edge(4 * i + 3, end_item, node_count).add_edge(
+                node_count,
+                Item::default(),
+                end_node,
+            );
+            node_count += 1;
         }
         ll1
     }

--- a/parsegen/src/parser/slr.rs
+++ b/parsegen/src/parser/slr.rs
@@ -3,7 +3,7 @@ use std::{fmt::Display, io::Cursor};
 use crate::{parser::grammar::Production, tokenizer::Token};
 
 use super::{
-    grammar::{Grammar, TokenOrEnd},
+    grammar::{Grammar, Node, TokenOrEnd},
     lgraph::{Bracket, Item, Lgraph},
 };
 
@@ -259,10 +259,12 @@ impl Lgraph {
                     )
                     .add_edge(
                         path_node + 1,
-                        Item::default().with_bracket(Some(Bracket::new(
-                            sym_idx + output_terminal_bracket_offset,
-                            false,
-                        ))),
+                        Item::default()
+                            .with_bracket(Some(Bracket::new(
+                                sym_idx + output_terminal_bracket_offset,
+                                false,
+                            )))
+                            .with_output(Some(Node::Leaf(sym.clone()))),
                         path_node + 2,
                     )
                     .add_edge(
@@ -295,10 +297,12 @@ impl Lgraph {
                     )
                     .add_edge(
                         path_node + 1,
-                        Item::default().with_bracket(Some(Bracket::new(
-                            sym_idx + output_terminal_bracket_offset,
-                            false,
-                        ))),
+                        Item::default()
+                            .with_bracket(Some(Bracket::new(
+                                sym_idx + output_terminal_bracket_offset,
+                                false,
+                            )))
+                            .with_output(Some(Node::Leaf(sym.clone()))),
                         to,
                     );
                 slr = slr.set_node_label(
@@ -370,10 +374,14 @@ impl Lgraph {
                             Bracket::new(to + state_bracket_offset, true),
                             Bracket::new(sym_id + non_output_terminal_bracket_offset, true),
                         ];
+                        let outputs = [Some(Node::RuleEnd(prod_idx, prod.lhs()))];
 
                         let mut prev = dispatch_node;
                         for i in 0..brackets.len() {
-                            let item = Item::default().with_bracket(Some(brackets[i]));
+                            let output = outputs.get(i).cloned().unwrap_or(None);
+                            let item = Item::default()
+                                .with_bracket(Some(brackets[i]))
+                                .with_output(output);
                             let next = if let Some((_, _, old)) =
                                 slr.edges().find(|(from, i, _)| from == &prev && i == &item)
                             {

--- a/parsegen/src/parser/slr.rs
+++ b/parsegen/src/parser/slr.rs
@@ -243,44 +243,32 @@ impl Lgraph {
                 slr = slr
                     .add_edge(
                         from,
-                        Item::new(
-                            None,
-                            None,
-                            Some(Bracket::new(
-                                sym_idx + non_output_terminal_bracket_offset,
-                                false,
-                            )),
-                        ),
+                        Item::default().with_bracket(Some(Bracket::new(
+                            sym_idx + non_output_terminal_bracket_offset,
+                            false,
+                        ))),
                         path_node,
                     )
                     .add_edge(
                         path_node,
-                        Item::new(
-                            None,
-                            None,
-                            Some(Bracket::new(sym_idx + output_terminal_bracket_offset, true)),
-                        ),
+                        Item::default().with_bracket(Some(Bracket::new(
+                            sym_idx + output_terminal_bracket_offset,
+                            true,
+                        ))),
                         path_node + 1,
                     )
                     .add_edge(
                         path_node + 1,
-                        Item::new(
-                            None,
-                            None,
-                            Some(Bracket::new(
-                                sym_idx + output_terminal_bracket_offset,
-                                false,
-                            )),
-                        ),
+                        Item::default().with_bracket(Some(Bracket::new(
+                            sym_idx + output_terminal_bracket_offset,
+                            false,
+                        ))),
                         path_node + 2,
                     )
                     .add_edge(
                         path_node + 2,
-                        Item::new(
-                            None,
-                            None,
-                            Some(Bracket::new(to + state_bracket_offset, true)),
-                        ),
+                        Item::default()
+                            .with_bracket(Some(Bracket::new(to + state_bracket_offset, true))),
                         to,
                     );
                 slr = slr.set_node_label(
@@ -292,32 +280,25 @@ impl Lgraph {
                 slr = slr
                     .add_edge(
                         from,
-                        Item::new(
-                            Some(TokenOrEnd::Token(sym.clone())),
-                            None,
-                            Some(Bracket::new(to + state_bracket_offset, true)),
-                        ),
+                        Item::default()
+                            .with_token(Some(TokenOrEnd::Token(sym.clone())))
+                            .with_bracket(Some(Bracket::new(to + state_bracket_offset, true))),
                         path_node,
                     )
                     .add_edge(
                         path_node,
-                        Item::new(
-                            None,
-                            None,
-                            Some(Bracket::new(sym_idx + output_terminal_bracket_offset, true)),
-                        ),
+                        Item::default().with_bracket(Some(Bracket::new(
+                            sym_idx + output_terminal_bracket_offset,
+                            true,
+                        ))),
                         path_node + 1,
                     )
                     .add_edge(
                         path_node + 1,
-                        Item::new(
-                            None,
-                            None,
-                            Some(Bracket::new(
-                                sym_idx + output_terminal_bracket_offset,
-                                false,
-                            )),
-                        ),
+                        Item::default().with_bracket(Some(Bracket::new(
+                            sym_idx + output_terminal_bracket_offset,
+                            false,
+                        ))),
                         to,
                     );
                 slr = slr.set_node_label(
@@ -363,20 +344,16 @@ impl Lgraph {
                     if !lr0.grammar.is_terminal(kernel_symbol.clone()) {
                         slr = slr.add_edge(
                             state_idx,
-                            Item::new(
-                                None,
-                                None,
-                                Some(Bracket::new(
-                                    sym_id + non_output_terminal_bracket_offset,
-                                    false,
-                                )),
-                            ),
+                            Item::default().with_bracket(Some(Bracket::new(
+                                sym_id + non_output_terminal_bracket_offset,
+                                false,
+                            ))),
                             prod_node,
                         )
                     } else {
                         slr = slr.add_edge(
                             state_idx,
-                            Item::new(Some(sym.clone()), None, None),
+                            Item::default().with_token(Some(sym.clone())),
                             prod_node,
                         );
                     }
@@ -396,7 +373,7 @@ impl Lgraph {
 
                         let mut prev = dispatch_node;
                         for i in 0..brackets.len() {
-                            let item = Item::new(None, None, Some(brackets[i]));
+                            let item = Item::default().with_bracket(Some(brackets[i]));
                             let next = if let Some((_, _, old)) =
                                 slr.edges().find(|(from, i, _)| from == &prev && i == &item)
                             {
@@ -441,17 +418,14 @@ impl Lgraph {
             if prod.rhs().len() == 0 {
                 slr = slr.add_edge(
                     prod_node,
-                    Item::new(
-                        None,
-                        None,
-                        Some(Bracket::new(prod_idx + prod_bracket_offset, true)),
-                    ),
+                    Item::default()
+                        .with_bracket(Some(Bracket::new(prod_idx + prod_bracket_offset, true))),
                     dispatch_node,
                 );
             } else {
                 slr = slr.add_edge(
                     prod_node,
-                    Item::new(None, None, Some(Bracket::Wildcard)),
+                    Item::default().with_bracket(Some(Bracket::Wildcard)),
                     path_node,
                 );
                 path_node += 1;
@@ -459,7 +433,7 @@ impl Lgraph {
                 for _ in 1..prod.rhs().len() {
                     slr = slr.add_edge(
                         path_node - 1,
-                        Item::new(None, None, Some(Bracket::Wildcard)),
+                        Item::default().with_bracket(Some(Bracket::Wildcard)),
                         path_node,
                     );
                     path_node += 1;
@@ -467,11 +441,8 @@ impl Lgraph {
 
                 slr = slr.add_edge(
                     path_node - 1,
-                    Item::new(
-                        None,
-                        None,
-                        Some(Bracket::new(prod_idx + prod_bracket_offset, true)),
-                    ),
+                    Item::default()
+                        .with_bracket(Some(Bracket::new(prod_idx + prod_bracket_offset, true))),
                     dispatch_node,
                 );
             }
@@ -504,14 +475,12 @@ impl Lgraph {
 
             slr = slr.add_edge(
                 path_node,
-                Item::new(
-                    Some(sym),
-                    None,
-                    Some(Bracket::new(
+                Item::default()
+                    .with_token(Some(sym))
+                    .with_bracket(Some(Bracket::new(
                         sym_id + non_output_terminal_bracket_offset,
                         true,
-                    )),
-                ),
+                    ))),
                 start_state,
             );
         }
@@ -520,25 +489,21 @@ impl Lgraph {
             .add_end_node(end_node)
             .add_edge(
                 end_node,
-                Item::new(None, None, Some(Bracket::Wildcard)),
+                Item::default().with_bracket(Some(Bracket::Wildcard)),
                 end_node,
             )
             .add_edge(
                 dispatch_node_offset + lr0.grammar.terminals().count(),
-                Item::new(
-                    None,
-                    None,
-                    Some(Bracket::new(start_prod_idx + prod_bracket_offset, false)),
-                ),
+                Item::default().with_bracket(Some(Bracket::new(
+                    start_prod_idx + prod_bracket_offset,
+                    false,
+                ))),
                 end_node,
             )
             .add_edge(
                 start_node,
-                Item::new(
-                    None,
-                    None,
-                    Some(Bracket::new(start_state + state_bracket_offset, true)),
-                ),
+                Item::default()
+                    .with_bracket(Some(Bracket::new(start_state + state_bracket_offset, true))),
                 path_node,
             )
     }

--- a/parsegen/src/parser/tests.rs
+++ b/parsegen/src/parser/tests.rs
@@ -4,7 +4,7 @@ use crate::{parser::lgraph::Bracket, tokenizer::Token};
 
 use super::{
     grammar::{Grammar, GrammarFromStrError, TokenOrEnd},
-    lgraph::{Lgraph, Stack},
+    lgraph::{Lgraph, Path, Stack},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -33,13 +33,11 @@ impl TestParser for RuntimeParser {
         self.g = Some(g);
         self.grammar = Some(grammar);
     }
-    fn parse(&self, toks: &[Token]) -> Result<String, TraverseError> {
-        let mut res = vec![];
-        let mut w = Cursor::new(&mut res);
-        let w = &mut w;
+    fn parse(&self, toks: &[Token]) -> Result<Path, TraverseError> {
         let g = self.g.as_ref().unwrap();
         let grammar = self.grammar.as_ref().unwrap();
         let terminal_count = grammar.terminals().count() + 1;
+        let mut path = Path::Empty(g.start_nodes().next().unwrap());
 
         let mut state = g.start_nodes().next().unwrap();
         let mut stack = Stack::new();
@@ -60,11 +58,10 @@ impl TestParser for RuntimeParser {
             let mut next_state = Some(state);
             while let Some(s) = next_state.take() {
                 state = s;
-                // print!("-> {s} -");
                 let mut has_consumed = false;
-                let mut bracket = None;
+                let mut edge = None;
 
-                for (_, item, next) in g.edges_from(state) {
+                for (from, item, to) in g.edges_from(state) {
                     let bracket_ok = item.bracket().map_or(true, |b| stack.can_accept(b));
                     let token_match = item.tok().map_or(false, |t| t == cur_tok);
                     let can_consume = need_to_consume && token_match;
@@ -81,39 +78,27 @@ impl TestParser for RuntimeParser {
                     if !bracket_ok || !look_ahead_ok || !token_ok {
                         continue;
                     }
-                    if next_state.is_some() {
+                    if edge.is_some() {
                         return Err(TraverseError::ConflictOn(state, cur_tok, stack.top()));
                     }
 
-                    bracket = item.bracket();
-                    next_state = Some(next);
+                    edge = Some((from, item, to));
                     has_consumed = can_consume;
                 }
-                if has_consumed {
-                    // print!("{cur_tok}");
-                    need_to_consume = false;
-                    // write!(w, "{}, ", cur_tok).unwrap();
-                    cur_tok = next_tok.take().unwrap();
-                }
-                if let Some(b) = bracket {
-                    // print!("{}", b);
-                    if !b.is_open() {
-                        let idx = stack.top().unwrap();
-                        if idx < terminal_count {
-                            let t = grammar
-                                .terminals()
-                                .nth(idx)
-                                .map(TokenOrEnd::Token)
-                                .unwrap_or(TokenOrEnd::End);
-                            write!(w, "{t}, ").unwrap();
-                        } else {
-                            grammar
-                                .productions()
-                                .nth(idx - terminal_count)
-                                .map(|p| write!(w, "{}[{}], ", p.lhs(), idx - terminal_count));
-                        }
+
+                if let Some(edge) = edge {
+                    next_state = Some(edge.2);
+                    if let Some(b) = edge.1.bracket() {
+                        assert!(stack.try_accept_mut(b));
                     }
-                    assert!(stack.try_accept_mut(b));
+                    path = path.append(edge);
+                } else {
+                    // return Err(TraverseError::NoWayToContinue(state, cur_tok, stack.top()));
+                }
+
+                if has_consumed {
+                    need_to_consume = false;
+                    cur_tok = next_tok.take().unwrap();
                 }
             }
 
@@ -129,13 +114,13 @@ impl TestParser for RuntimeParser {
             return Err(TraverseError::StackNotEmptied(stack));
         }
 
-        Ok(String::from_utf8(res)?)
+        Ok(path)
     }
 }
 
 pub trait TestParser {
     fn init(&mut self, g: Lgraph, grammar: Grammar);
-    fn parse(&self, toks: &[Token]) -> Result<String, TraverseError>;
+    fn parse(&self, toks: &[Token]) -> Result<Path, TraverseError>;
 }
 
 fn parens_grammar_simple() -> Grammar {
@@ -253,11 +238,10 @@ pub fn ll1_gauntlet(t: &mut dyn TestParser) {
                 acc += " ";
                 acc
             });
-            assert_eq!(
-                t.parse(&toks),
-                Ok(tree),
-                "failed on \n\tgrammar={grammar}\n\tinput={s}\n",
-            );
+            let path = t.parse(&toks).unwrap();
+            println!("{}", path);
+            let res = path.to_parse_tree(&grammar);
+            assert_eq!(res, tree, "\tgrammar: {grammar}\n\ttoks: {s}");
         }
     }
 }
@@ -337,11 +321,8 @@ pub fn slr_gauntlet(t: &mut dyn TestParser) {
                 acc += " ";
                 acc
             });
-            assert_eq!(
-                t.parse(&toks),
-                Ok(tree.strip_suffix("$, ").unwrap().to_string()),
-                "failed on \n\tgrammar={grammar}\n\tinput={s}\n",
-            );
+            let res = t.parse(&toks).map(|p| p.to_parse_tree(&grammar));
+            assert_eq!(res, Ok(tree), "\tgrammar: {grammar}\n\ttoks: {s}");
         }
     }
 }

--- a/parsegen/src/parser/tests.rs
+++ b/parsegen/src/parser/tests.rs
@@ -239,7 +239,6 @@ pub fn ll1_gauntlet(t: &mut dyn TestParser) {
                 acc
             });
             let path = t.parse(&toks).unwrap();
-            println!("{}", path);
             let res = path.to_parse_tree(&grammar);
             assert_eq!(res, tree, "\tgrammar: {grammar}\n\ttoks: {s}");
         }
@@ -321,16 +320,17 @@ pub fn slr_gauntlet(t: &mut dyn TestParser) {
                 acc += " ";
                 acc
             });
-            let res = t.parse(&toks).map(|p| p.to_parse_tree(&grammar));
-            assert_eq!(res, Ok(tree), "\tgrammar: {grammar}\n\ttoks: {s}");
+            let path = t.parse(&toks).unwrap();
+            let res = path.to_parse_tree(&grammar);
+            assert_eq!(res, tree, "\tgrammar: {grammar}\n\ttoks: {s}");
         }
     }
 }
 
 #[test]
 fn runtime_parser() {
-    writeln!(std::io::stderr(), "testing ll1").unwrap();
+    println!("testing ll1");
     ll1_gauntlet(&mut RuntimeParser::default());
-    writeln!(std::io::stderr(), "testing slr").unwrap();
+    println!("testing slr");
     slr_gauntlet(&mut RuntimeParser::default());
 }


### PR DESCRIPTION
A new optional `output` field has been added to `Item`s. It tells the parser directly what output to produce (consuming a token, applying a rule), instead of the weird system with bracket indices. Also, `Path` and `ParseTree` are now the main mechanisms of checking test results, instead of storing the parser output as a string